### PR TITLE
Change writeFileToFlash() call for new Arcada

### DIFF
--- a/src/emuapi.cpp
+++ b/src/emuapi.cpp
@@ -82,7 +82,8 @@ uint8_t *emu_LoadROM(char *filename) {
   tft.stop();
   arcada.display->fillScreen(ARCADA_CYAN);
   arcada.infoBox("Loading ROM into FLASH memory...", 0);
-  uint8_t *romdata = arcada.writeFileToFlash(filename, DEFAULT_FLASH_ADDRESS);
+//  uint8_t *romdata = arcada.writeFileToFlash(filename, DEFAULT_FLASH_ADDRESS);
+  uint8_t *romdata = arcada.writeFileToFlash(filename);
   Serial.printf(" into address $%08x", (uint32_t)romdata);
   if ((uint32_t)romdata == 0) {
     emu_Halt("Unable to load file into FLASH, maybe too large?");


### PR DESCRIPTION
Looks like PaintYourDragon removed the arcada.writeFileToFlash(char *, int) override in https://github.com/adafruit/Adafruit_Arcada/commit/ad4715e2d8aa022e29d93bc52100f30e1cff9818

Without this change (as the master branch is), nofrendo_arcada doesn't compile because the arcada.writeFileToFlash(char *, int) override isn't found.